### PR TITLE
Fixed bug where data is never set

### DIFF
--- a/jsignature/static/js/django_jsignature.js
+++ b/jsignature/static/js/django_jsignature.js
@@ -3,7 +3,7 @@ $(document).ready(function() {
   /* Each time user is done drawing a stroke, update value of hidden input */
   $(document).delegate(".jsign-container", "change", function(e) {
     var jSignature_data = $(this).jSignature('getData', 'native');
-    var django_field_name = $(this).attr('id').split('_')[1];
+    var django_field_name = $(this).attr('id').split(/_(.+)/)[1];
     $('#id_' + django_field_name).val(JSON.stringify(jSignature_data));
   });
 


### PR DESCRIPTION
If the field name contains an underscore, the split will only take the first part of the field name. This causes the form data to never actually update.

I changed the split into a regex to greedily split on the first underscore, keeping the field name intact.
