### PR TITLE
forced box size to int

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ env:
   - DJANGO_VERSION=1.7 MODULE=jsignature.tests
 
 install:
-  - pip install -r requirements.txt --use-mirrors
-  - pip install -q Django==$DJANGO_VERSION --use-mirrors
+  - pip install -r requirements.txt
+  - pip install -q Django==$DJANGO_VERSION
   - pip install coverage
 
 script: coverage run quicktest.py $MODULE

--- a/jsignature/utils.py
+++ b/jsignature/utils.py
@@ -23,8 +23,8 @@ def draw_signature(data, as_file=False):
         raise ValueError
 
     # Compute box
-    width = max(chain(*[d['x'] for d in drawing])) + 10
-    height = max(chain(*[d['y'] for d in drawing])) + 10
+    width = int(round(max(chain(*[d['x'] for d in drawing])))) + 10
+    height = int(round(max(chain(*[d['y'] for d in drawing])))) + 10
 
     # Draw image
     im = Image.new("RGBA", (width*AA, height*AA))


### PR DESCRIPTION
Kept getting TypeError: integer argument expected, got float in jsignature/utils.py", line 30, in draw_signature. This rounds up the biggest float it finds when looking for width/height and forces it to int, for signatures that have floats as coordinates. 
