### PR TITLE
Updated to fix an error when using jSignature field with Django 2

### DIFF
--- a/jsignature/fields.py
+++ b/jsignature/fields.py
@@ -13,7 +13,7 @@ from .forms import (
     JSIGNATURE_EMPTY_VALUES)
 
 
-class JSignatureField(six.with_metaclass(models.SubfieldBase, models.Field)):
+class JSignatureField(models.Field):
     """
     A model field handling a signature captured with jSignature
     """

--- a/jsignature/widgets.py
+++ b/jsignature/widgets.py
@@ -59,7 +59,7 @@ class JSignatureWidget(HiddenInput):
             return json.dumps(value)
         raise ValidationError('Invalid format.')
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         """ Render widget """
         # Build config
         jsign_id = self.build_jsignature_id(name)


### PR DESCRIPTION
This adds the missing `renderer` argument to the `JSignatureField.render` method.

The whole method could probably be re-written to better leverage changes in more recent version of Django, but this will get users up and running in the interim.