### PR TITLE
Fix jquery dependency for Django >2.2 version

### DIFF
--- a/jsignature/widgets.py
+++ b/jsignature/widgets.py
@@ -27,7 +27,8 @@ class JSignatureWidget(HiddenInput):
     is_hidden = False
 
     class Media:
-        js = ('js/jSignature.min.js',
+        js = ('admin/js/jquery.init.js',
+              'js/jSignature.min.js',
               'js/django_jsignature.js')
 
     def __init__(self, attrs=None, jsignature_attrs=None):


### PR DESCRIPTION
Django changed the way media assets are merged, now using a topological sort algorithm. Dependencies are now needed to be added in the media so they are recognized by the algorithm.