### PR TITLE
Filter out null values in signature data

### DIFF
--- a/jsignature/utils.py
+++ b/jsignature/utils.py
@@ -14,9 +14,11 @@ def draw_signature(data, as_file=False):
         `data` can be a json object (list in fact) or a json string
         if `as_file` is True, a temp file is returned instead of Image instance
     """
+    def _remove_empty_pts(pt):
+        return {'x': list(filter(None, pt['x'])), 'y': list(filter(None, pt['y']))}
 
     if type(data) is str:
-        drawing = json.loads(data)
+        drawing = json.loads(data, object_hook=_remove_empty_pts)
     elif type(data) is list:
         drawing = data
     else:

--- a/jsignature/utils.py
+++ b/jsignature/utils.py
@@ -15,8 +15,8 @@ def draw_signature(data, as_file=False):
         if `as_file` is True, a temp file is returned instead of Image instance
     """
     def _remove_empty_pts(pt):
-        return {'x': list(filter(None, pt['x'])), 'y': list(filter(None, pt['y']))}
-
+        return {'x': list(filter(lambda n: n is not None, pt['x'])), 'y': list(filter(lambda n: n is not None, pt['y']))}
+    
     if type(data) is str:
         drawing = json.loads(data, object_hook=_remove_empty_pts)
     elif type(data) is list:


### PR DESCRIPTION
Null values in the signature data will cause the compute box calculation to fail. Filter them out during json.loads