### PR TITLE
Accept float x,y values

### DIFF
--- a/jsignature/utils.py
+++ b/jsignature/utils.py
@@ -23,8 +23,8 @@ def draw_signature(data, as_file=False):
         raise ValueError
 
     # Compute box
-    width = max(chain(*[d['x'] for d in drawing])) + 10
-    height = max(chain(*[d['y'] for d in drawing])) + 10
+    width = int(round(max(chain(*[d['x'] for d in drawing])))) + 10
+    height = int(round(max(chain(*[d['y'] for d in drawing])))) + 10
 
     # Draw image
     im = Image.new("RGBA", (width*AA, height*AA))

--- a/tests/test_faulty_signature.py
+++ b/tests/test_faulty_signature.py
@@ -1,0 +1,12 @@
+import json
+
+from django.test import SimpleTestCase
+
+from jsignature.templatetags.jsignature_filters import signature_base64
+
+FAULTY_SIGNATURE = [{"x": [120.00675156801722, 116.11464070635179, 114.16858527551909], "y": [83.0316983821957, 76.54484694608666, 224.44505968937275]}, {"x": [161.52260075911508, 165.4147116207805, 173.84761848772226, 184.2265807854967, 201.0923945193802], "y": [84.97775381302841, 79.78827266414118, 72.00405094081033, 62.922458930257676, 56.43560749414864]}]
+DUMMY_STR_VALUE = json.dumps(FAULTY_SIGNATURE)
+
+class TemplateFilterFailedTest(SimpleTestCase):
+    def test_throw_error(self):
+        output = signature_base64(DUMMY_STR_VALUE)


### PR DESCRIPTION
On some browsers the following javascript returns float instead of integer values:

https://github.com/fle/django-jsignature/blob/a740767a06ce6a6abec58bd92db551310e682652/jsignature/static/js/django_jsignature.js#L12

When the data is rendered, it throws:
```
  File "/home/ec2-user/python-libs/django-jsignature/jsignature/templatetags/jsignature_filters.py", line 17, in signature_base64
    draw_signature(value).save(in_mem_file, format="PNG")
  File "/home/ec2-user/python-libs/django-jsignature/jsignature/utils.py", line 30, in draw_signature
    im = Image.new("RGBA", (width*AA, height*AA))
  File "/home/ec2-user/python-libs/env/lib64/python3.8/site-packages/PIL/Image.py", line 2642, in new
    return im._new(core.fill(mode, size, color))
TypeError: integer argument expected, got float
```