### PR TITLE
Fix issue with uggettext_lazy

### DIFF
--- a/jsignature/mixins.py
+++ b/jsignature/mixins.py
@@ -5,7 +5,7 @@
 import json
 from datetime import datetime
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from .fields import JSignatureField
 
 

--- a/jsignature/widgets.py
+++ b/jsignature/widgets.py
@@ -11,7 +11,7 @@ from django.core import validators
 from django.core.exceptions import ValidationError
 
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from jsignature.settings import JSIGNATURE_DEFAULT_CONFIG
 
 JSIGNATURE_EMPTY_VALUES = validators.EMPTY_VALUES + ('[]', )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 
 setup(
     name='django-jsignature',
-    version='0.10',
+    version='0.11',
     author='Florent Lebreton',
     author_email='florent.lebreton@makina-corpus.com',
     url='https://github.com/fle/django-jsignature',


### PR DESCRIPTION
As documented in #19, `ugettext_lazy` has been removed in the latest versions of Django and has been replaced with `gettext_lazy`

This PR addresses the necessary code changes required to fix this.